### PR TITLE
Minor cleanup of OpenTSDBWriterTests

### DIFF
--- a/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
+++ b/jmxtrans-output/jmxtrans-output-core/src/test/java/com/googlecode/jmxtrans/model/output/OpenTSDBGenericWriterTests.java
@@ -6,12 +6,9 @@ import com.google.common.collect.ImmutableMap;
 import com.googlecode.jmxtrans.exceptions.LifecycleException;
 import com.googlecode.jmxtrans.model.Query;
 import com.googlecode.jmxtrans.model.Result;
-import org.assertj.core.api.Assertions;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -27,6 +24,9 @@ import java.util.Map;
 import static com.google.common.collect.Maps.newHashMap;
 import static java.lang.Boolean.FALSE;
 import static java.lang.Boolean.TRUE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -49,8 +49,8 @@ public class OpenTSDBGenericWriterTests {
 
 	@Before
 	public void setupTest() {
-		this.mockQuery = Mockito.mock(Query.class);
-		this.mockResult = Mockito.mock(Result.class);
+		this.mockQuery = mock(Query.class);
+		this.mockResult = mock(Result.class);
 
 		// Setup test data
 		tvAddHostnameTagDefault = true;
@@ -61,10 +61,10 @@ public class OpenTSDBGenericWriterTests {
 		tvMetricLinesSent = new LinkedList<String>();
 
 		// Setup common mock interactions.
-		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("x-att1-x", (Object) "120021"));
-		Mockito.when(this.mockResult.getAttributeName()).thenReturn("X-ATT-X");
-		Mockito.when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
-		Mockito.when(this.mockResult.getTypeName()).
+		when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("x-att1-x", (Object) "120021"));
+		when(this.mockResult.getAttributeName()).thenReturn("X-ATT-X");
+		when(this.mockResult.getClassName()).thenReturn("X-DOMAIN.PKG.CLASS-X");
+		when(this.mockResult.getTypeName()).
 				thenReturn("Type=x-type-x,Group=x-group-x,Other=x-other-x,Name=x-name-x");
 
 	}
@@ -77,7 +77,7 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertEquals(1, tvMetricLinesSent.size());
+		assertThat(tvMetricLinesSent).hasSize(1);
 		validateMergedTypeNameValues(tvMetricLinesSent.get(0), true);
 	}
 
@@ -89,7 +89,7 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertEquals(1, tvMetricLinesSent.size());
+		assertThat(tvMetricLinesSent).hasSize(1);
 		validateMergedTypeNameValues(tvMetricLinesSent.get(0), true);
 	}
 
@@ -102,7 +102,7 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertEquals(1, tvMetricLinesSent.size());
+		assertThat(tvMetricLinesSent).hasSize(1);
 		validateMergedTypeNameValues(tvMetricLinesSent.get(0), false);
 	}
 
@@ -116,17 +116,17 @@ public class OpenTSDBGenericWriterTests {
 				false,
 				settings);
 
-		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
+		when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
 		// Verify empty tag map.
-		Assertions.assertThat(writer.getTypeNames()).isEmpty();
+		assertThat(writer.getTypeNames()).isEmpty();
 
 		writer.start();
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertTrue(
-				this.tvMetricLinesSent.get(0).matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021 host=[^ ]*$"));
+		assertThat(this.tvMetricLinesSent.get(0))
+				.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021 host=[^ ]*$");
 	}
 
 	@Test
@@ -144,11 +144,12 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches(".*\\bhost=.*"));
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches(".*\\bx-tag1-x=x-tag1val-x\\b.*"));
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches(".*\\bx-tag2-x=x-tag2val-x\\b.*"));
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches(".*\\bx-tag3-x=x-tag3val-x\\b.*"));
+		assertThat(this.tvMetricLinesSent.get(0))
+				.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*")
+				.matches(".*\\bhost=.*")
+				.matches(".*\\bx-tag1-x=x-tag1val-x\\b.*")
+				.matches(".*\\bx-tag2-x=x-tag2val-x\\b.*")
+				.matches(".*\\bx-tag3-x=x-tag3val-x\\b.*");
 	}
 
 	@Test
@@ -159,9 +160,9 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertEquals(1, tvMetricLinesSent.size());
+		assertThat(tvMetricLinesSent).hasSize(1);
 		validateMergedTypeNameValues(tvMetricLinesSent.get(0), true);
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches(".*host=.*"));
+		assertThat(this.tvMetricLinesSent.get(0)).matches(".*host=.*");
 	}
 
 	@Test
@@ -172,7 +173,7 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertFalse(this.tvMetricLinesSent.get(0).matches(".*\\bhost=.*"));
+		assertThat(this.tvMetricLinesSent.get(0)).doesNotMatch(".*\\bhost=.*");
 	}
 
 	@Test
@@ -180,41 +181,42 @@ public class OpenTSDBGenericWriterTests {
 		OpenTSDBGenericWriter writer = createWriter();
 
 		ImmutableMap<String, Object> values = ImmutableMap.of();
-		Mockito.when(this.mockResult.getValues()).thenReturn(values);
+		when(this.mockResult.getValues()).thenReturn(values);
 
 		writer.start();
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertEquals(0, this.tvMetricLinesSent.size());
+		assertThat(tvMetricLinesSent).isEmpty();
 	}
 
 	@Test
 	public void testOneValueMatchingAttribute() throws Exception {
 		OpenTSDBGenericWriter writer = createWriter();
 
-		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
+		when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021"));
 
 		writer.start();
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches(".*\\bhost=.*"));
-		Assert.assertFalse(this.tvMetricLinesSent.get(0).matches(".*\\btype=.*"));
+		assertThat(this.tvMetricLinesSent.get(0))
+				.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*")
+				.matches(".*\\bhost=.*")
+				.doesNotMatch(".*\\btype=.*");
 	}
 
 	@Test
 	public void testMultipleValuesWithMatchingAttribute() throws Exception {
 		OpenTSDBGenericWriter writer = createWriter();
 
-		Mockito.when(this.mockResult.getValues()).
+		when(this.mockResult.getValues()).
 				thenReturn(ImmutableMap.of("X-ATT-X", (Object) "120021", "XX-ATT-XX", (Object) "210012"));
 
 		writer.start();
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
-		Assert.assertEquals(2, this.tvMetricLinesSent.size());
+		assertThat(tvMetricLinesSent).hasSize(2);
 
 		String xLine;
 		String xxLine;
@@ -226,24 +228,26 @@ public class OpenTSDBGenericWriterTests {
 			xxLine = this.tvMetricLinesSent.get(1);
 		}
 
-		Assert.assertTrue(xLine.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
-		Assert.assertTrue(xLine.matches(".*\\btype=X-ATT-X\\b.*"));
+		assertThat(xLine)
+				.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*")
+				.matches(".*\\btype=X-ATT-X\\b.*");
 
-		Assert.assertTrue(xxLine.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 210012.*"));
-		Assert.assertTrue(xxLine.matches(".*\\btype=XX-ATT-XX\\b.*"));
+		assertThat(xxLine)
+				.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 210012.*")
+				.matches(".*\\btype=XX-ATT-XX\\b.*");
 	}
 
 	@Test
 	public void testNonNumericValue() throws Exception {
 		OpenTSDBGenericWriter writer = createWriter();
 
-		Mockito.when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "THIS-IS-NOT-A-NUMBER"));
+		when(this.mockResult.getValues()).thenReturn(ImmutableMap.of("X-ATT-X", (Object) "THIS-IS-NOT-A-NUMBER"));
 
 		writer.start();
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertEquals(0, this.tvMetricLinesSent.size());
+		assertThat(tvMetricLinesSent).isEmpty();
 	}
 
 	@Test
@@ -254,7 +258,7 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 		writer.stop();
 
-		Assert.assertTrue(this.tvMetricLinesSent.get(0).matches("^xx-jexl-constant-name-xx 0 120021.*"));
+		assertThat(tvMetricLinesSent.get(0)).matches("^xx-jexl-constant-name-xx 0 120021.*");
 	}
 
 	@Test(expected = LifecycleException.class)
@@ -306,27 +310,27 @@ public class OpenTSDBGenericWriterTests {
 	public void testHooksCalled() throws Exception {
 		OpenTSDBGenericWriter writer = createWriter();
 		writer.start();
-		Assert.assertTrue(prepareSenderCalled);
-		Assert.assertFalse(shutdownSenderCalled);
-		Assert.assertFalse(startOutputCalled);
-		Assert.assertFalse(finishOutputCalled);
+		assertThat(prepareSenderCalled).isTrue();
+		assertThat(shutdownSenderCalled).isFalse();
+		assertThat(startOutputCalled).isFalse();
+		assertThat(finishOutputCalled).isFalse();
 
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
-		Assert.assertTrue(prepareSenderCalled);
-		Assert.assertFalse(shutdownSenderCalled);
-		Assert.assertTrue(startOutputCalled);
-		Assert.assertTrue(finishOutputCalled);
+		assertThat(prepareSenderCalled).isTrue();
+		assertThat(shutdownSenderCalled).isFalse();
+		assertThat(startOutputCalled).isTrue();
+		assertThat(finishOutputCalled).isTrue();
 
 		writer.stop();
-		Assert.assertTrue(prepareSenderCalled);
-		Assert.assertTrue(shutdownSenderCalled);
-		Assert.assertTrue(startOutputCalled);
-		Assert.assertTrue(finishOutputCalled);
+		assertThat(prepareSenderCalled).isTrue();
+		assertThat(shutdownSenderCalled).isTrue();
+		assertThat(startOutputCalled).isTrue();
+		assertThat(finishOutputCalled).isTrue();
 
 	}
 
 	@Test
-	public void testDebugEanbled() throws Exception {
+	public void testDebugEnabled() throws Exception {
 		OpenTSDBGenericWriter writer = createWriter(ImmutableMap.of("host", (Object) "localhost", "port", 4242, "debug", true));
 
 		writer.start();
@@ -334,19 +338,17 @@ public class OpenTSDBGenericWriterTests {
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 	}
 
-	@Test
+	@Test(expected = UnknownHostException.class)
 	public void testLocalhostUnknownHostException() throws Exception {
 		UnknownHostException unknownHostException = new UnknownHostException("X-TEST-UHE-X");
 		try {
 			PowerMockito.mockStatic(InetAddress.class);
 			PowerMockito.when(InetAddress.getLocalHost()).thenThrow(unknownHostException);
 
-			OpenTSDBGenericWriter writer = createWriter();
-
-			Assert.fail("LifecycleException missing");
+			createWriter();
 		} catch (UnknownHostException ex) {
-			// Verify.
-			Assert.assertSame(unknownHostException, ex);
+			assertThat(ex).hasMessage("X-TEST-UHE-X");
+			throw ex;
 		}
 	}
 
@@ -356,10 +358,10 @@ public class OpenTSDBGenericWriterTests {
 	@Test
 	public void testNullHostTagname() throws Exception {
 		// Prepare.
-		InetAddress mockInetAddress = Mockito.mock(InetAddress.class);
+		InetAddress mockInetAddress = mock(InetAddress.class);
 		PowerMockito.mockStatic(InetAddress.class);
 		PowerMockito.when(InetAddress.getLocalHost()).thenReturn(mockInetAddress);
-		Mockito.when(mockInetAddress.getHostName()).thenReturn(null);
+		when(mockInetAddress.getHostName()).thenReturn(null);
 		OpenTSDBGenericWriter writer = createWriter("addHostnameTag", true);
 
 
@@ -367,8 +369,7 @@ public class OpenTSDBGenericWriterTests {
 		writer.start();
 		writer.doWrite(null, this.mockQuery, ImmutableList.of(this.mockResult));
 
-		// Validate.
-		Assert.assertFalse(this.tvMetricLinesSent.get(0).matches(".*\\bhost=.*"));    // Ensure host tag is excluded
+		assertThat(tvMetricLinesSent.get(0)).doesNotMatch(".*\\bhost=.*");    // Ensure host tag is excluded
 	}
 
 	protected OpenTSDBGenericWriter createWriter() throws LifecycleException, UnknownHostException {
@@ -393,16 +394,18 @@ public class OpenTSDBGenericWriterTests {
 
 	protected void validateMergedTypeNameValues(String resultString, boolean mergedInd) {
 		if (mergedInd) {
-			Assert.assertTrue(resultString.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
-			Assert.assertTrue(resultString.matches(".*\\btype=x-att1-x\\b.*"));
-			Assert.assertTrue(resultString.matches(".*\\bTypeGroupNameMissing=x-type-x_x-group-x_x-name-x\\b.*"));
+			assertThat(resultString)
+					.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*")
+					.matches(".*\\btype=x-att1-x\\b.*")
+					.matches(".*\\bTypeGroupNameMissing=x-type-x_x-group-x_x-name-x\\b.*");
 		} else {
-			Assert.assertTrue(resultString.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*"));
-			Assert.assertTrue(resultString.matches(".*\\btype=x-att1-x\\b.*"));
-			Assert.assertTrue(resultString.matches(".*\\bType=x-type-x\\b.*"));
-			Assert.assertTrue(resultString.matches(".*\\bGroup=x-group-x\\b.*"));
-			Assert.assertTrue(resultString.matches(".*\\bName=x-name-x\\b.*"));
-			Assert.assertTrue(resultString.matches(".*\\bMissing=(\\s.*|$)"));
+			assertThat(resultString)
+					.matches("^X-DOMAIN.PKG.CLASS-X\\.X-ATT-X 0 120021.*")
+					.matches(".*\\btype=x-att1-x\\b.*")
+					.matches(".*\\bType=x-type-x\\b.*")
+					.matches(".*\\bGroup=x-group-x\\b.*")
+					.matches(".*\\bName=x-name-x\\b.*")
+					.matches(".*\\bMissing=(\\s.*|$)");
 		}
 	}
 


### PR DESCRIPTION
This is all very minor, but makes the test easier to read IMHO. There is still a dependency on PowerMock. To keep the same test coverage, I should extract the resolving of local hostname, but that's more effort than I am willing to put into this at the moment. I almost think I should just remove those tests as they are really corner cases and are fairly costly.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/ivan-gusev/jmxtrans/pull/1%23issuecomment-107696651%22%2C%20%22https%3A//github.com/ivan-gusev/jmxtrans/pull/1%23issuecomment-107812287%22%2C%20%22https%3A//github.com/ivan-gusev/jmxtrans/pull/1%23issuecomment-107813269%22%2C%20%22https%3A//github.com/ivan-gusev/jmxtrans/pull/1%23issuecomment-107816893%22%2C%20%22https%3A//github.com/ivan-gusev/jmxtrans/pull/1%23issuecomment-107827159%22%2C%20%22https%3A//github.com/ivan-gusev/jmxtrans/pull/1%23issuecomment-107829045%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev/jmxtrans/pull/1%23issuecomment-107696651%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22You%20might%20want%20to%20have%20a%20look%20into%20this%20before%20I%20merge.%20You%20can%20either%20merge%20and%20squash%20it%20in%20your%20PR%2C%20or%20I%27ll%20do%20it%20on%20my%20side%20with%20no%20news%20from%20you.%5Cr%5Cn%5Cr%5CnAgain%2C%20thanks%20for%20your%20help%20%21%22%2C%20%22created_at%22%3A%20%222015-06-01T20%3A26%3A52Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40gehel%20I%20am%20bit%20confused%20here.%20It%20shows%20that%20I%20have%20completely%20removed%20powermock%20stuff%20and%20setupTest%28%29%20function%20in%20previous/parent%20commit%3A%20%20fc977ae%5Cr%5CnNow%20I%27m%20seeing%20both%20powermock%20imports%20and%20setupTest%28%29%20resurrected%20in%20this%20commit%20again%20as%20if%20they%20were%20never%20removed.%5Cr%5CnI%20actually%20discardeded%20%20setupTest%28%29%20completely%20as%20variables%20that%20it%20takes%20care%20to%20setup%20are%20actually%20never%20used%20in%20any%20tests%20that%20left.%20%22%2C%20%22created_at%22%3A%20%222015-06-02T05%3A32%3A24Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%2C%20%7B%22body%22%3A%20%22Most%20probably%20my%20bad%20...%20I%20probably%20did%20not%20start%20my%20rework%20from%20your%20latest%20commit.%20Let%20me%20check%20...%22%2C%20%22created_at%22%3A%20%222015-06-02T05%3A39%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20have%20no%20idea%20what%20I%20did%20...%20but%20the%20full%20cleanup%20of%20most%20tests%20in%20%60OpenTSDBWriterTests%60%20is%20probably%20a%20bit%20too%20much.%20I%20had%20a%20problem%20with%20the%20ones%20relying%20on%20PowerMock%2C%20not%20necessarily%20the%20ones%20relying%20only%20on%20Mockito.%20I%27ll%20see%20if%20I%20can%20clean%20that%20this%20evening%20or%20else%20I%27ll%20merge%20your%20PR%20as%20is.%5Cr%5Cn%5Cr%5CnSorry%20for%20my%20mess%20...%22%2C%20%22created_at%22%3A%20%222015-06-02T05%3A50%3A00Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1415765%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/gehel%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20looks%20like%20you%20want%20to%20keep%20testSuccessfulSendOpenTSDBResponse%7B1%2C2%2C3%7D%20tests%2C%20but%20they%20are%20completely%20useless%20as%20OpenTSDB%20never%20responds%20to%20sender%20as%20part%20of%20telnet%20protocol.%20If%20these%20tests%20are%20not%20needed%20then%20setupTest%28%29%20can%20be%20removed%20thus%20allowing%20PowerMock%20to%20be%20purged%20completely.%20This%20is%20pretty%20much%20what%20I%20did%20in%20fc977ae%5Cr%5CnIf%20you%20agree%20then%20the%20best%20option%20would%20be%3A%5Cr%5Cn-%20close%20this%20PR%5Cr%5Cn-%20I%20will%20implement%20static%20imports%20as%20you%20suggest%20in%20this%20PR%20and%20add%20it%20as%20new%20commit%20to%20tsdbtcp%20branch%20that%20has%20pending%20PR%20into%20main%20jmxtrans%20repo%5Cr%5Cn-%20if%20all%20okay%2C%20you%27ll%20merge%22%2C%20%22created_at%22%3A%20%222015-06-02T06%3A40%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%2C%20%7B%22body%22%3A%20%22test%7B%2A%7DIOException%20are%20pretty%20much%20obsolete%20with%20pool%20handling%20connections%22%2C%20%22created_at%22%3A%20%222015-06-02T06%3A45%3A42Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/3947391%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/ivan-gusev%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/ivan-gusev/jmxtrans/pull/1#issuecomment-107696651'>General Comment</a></b>
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> You might want to have a look into this before I merge. You can either merge and squash it in your PR, or I'll do it on my side with no news from you.
  Again, thanks for your help !
- <a href='https://github.com/ivan-gusev'><img border=0 src='https://avatars.githubusercontent.com/u/3947391?v=3' height=16 width=16'></a> @gehel I am bit confused here. It shows that I have completely removed powermock stuff and setupTest() function in previous/parent commit:  fc977ae
  Now I'm seeing both powermock imports and setupTest() resurrected in this commit again as if they were never removed.
  I actually discardeded  setupTest() completely as variables that it takes care to setup are actually never used in any tests that left.
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> Most probably my bad ... I probably did not start my rework from your latest commit. Let me check ...
- <a href='https://github.com/gehel'><img border=0 src='https://avatars.githubusercontent.com/u/1415765?v=3' height=16 width=16'></a> I have no idea what I did ... but the full cleanup of most tests in `OpenTSDBWriterTests` is probably a bit too much. I had a problem with the ones relying on PowerMock, not necessarily the ones relying only on Mockito. I'll see if I can clean that this evening or else I'll merge your PR as is.
  Sorry for my mess ...
- <a href='https://github.com/ivan-gusev'><img border=0 src='https://avatars.githubusercontent.com/u/3947391?v=3' height=16 width=16'></a> It looks like you want to keep testSuccessfulSendOpenTSDBResponse{1,2,3} tests, but they are completely useless as OpenTSDB never responds to sender as part of telnet protocol. If these tests are not needed then setupTest() can be removed thus allowing PowerMock to be purged completely. This is pretty much what I did in fc977ae
  If you agree then the best option would be:
- close this PR
- I will implement static imports as you suggest in this PR and add it as new commit to tsdbtcp branch that has pending PR into main jmxtrans repo
- if all okay, you'll merge
- <a href='https://github.com/ivan-gusev'><img border=0 src='https://avatars.githubusercontent.com/u/3947391?v=3' height=16 width=16'></a> test{*}IOException are pretty much obsolete with pool handling connections

<a href='https://www.codereviewhub.com/ivan-gusev/jmxtrans/pull/1?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/ivan-gusev/jmxtrans/pull/1?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/ivan-gusev/jmxtrans/pull/1'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>
